### PR TITLE
i2528: Don't use linked backups

### DIFF
--- a/etc/barman.d.in/template
+++ b/etc/barman.d.in/template
@@ -10,8 +10,3 @@ slot_name = $slot_name
 # at present each backup costs a couple of hundred GB so without infinite
 # disk space (and money on AWS) this can't be unbounded
 retention_policy = RECOVERY WINDOW OF 3 MONTHS
-
-# http://docs.pgbarman.org/release/2.5/#backup-features
-# > incremental backup, by reusing the last backup for a server and creating
-# > a hard link of the unchanged files (for backup space and time reduction)
-reuse_backup = link


### PR DESCRIPTION
Reverts part of 8eebad2

"IMPORTANT: The reuse_backup option can’t be used with the postgres backup method at this time."